### PR TITLE
Allow log entries to be set as fields at the root of the object sent to logz.io

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       GO111MODULE: on
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,10 @@
 name: Tests
 
-on: [pull_request]
-
+on: 
+  pull_request: 
+    types: [opened, synchronize]
+  push:
+    branches: ['main']
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,4 @@ jobs:
       - name: Test
         working-directory: ./logzio-lambda-extensions-logs/utils
         run: go test -v -race -covermode=atomic -coverprofile=coverage.out
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,6 @@
 name: Tests
 
-on: 
-  pull_request: 
-    types: [opened, synchronize]
-  push:
-    branches: ['main']
+on: [pull_request]
 
 jobs:
   test:
@@ -25,4 +21,3 @@ jobs:
       - name: Test
         working-directory: ./logzio-lambda-extensions-logs/utils
         run: go test -v -race -covermode=atomic -coverprofile=coverage.out
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on: [pull_request]
 
+
 jobs:
   test:
     env:

--- a/logzio-lambda-extensions-logs/README.md
+++ b/logzio-lambda-extensions-logs/README.md
@@ -150,7 +150,7 @@ This project uses an external module for its Grok parsing. To learn more about i
 
 ### Nested fields
 
-As of v0.2.0 the extension can detect if a log is in a JSON format, and to parse the fields to appear as nested fields in the Logz.io app.
+As of v0.2.0, by default, the extension can detect if a log is in a JSON format, and to parse the fields to appear as nested fields in the Logz.io app.
 For example, the following log:
 
 ```
@@ -161,6 +161,19 @@ Will appear under the fields:
 ```
 message_nested.foo: bar
 message_nested.field2: val2
+```
+
+You can also use set the `FLATTEN_NESTED_MESSAGE` environment variable to make it so that the log fields will be set as fields at the root of the object instead of under `message_nested`. It is useful in cases where the passed object is in fact meant to be that of a message plus metadata fields.  
+For example, the following log:
+
+```
+{ "message": "hello", "foo": "bar" }
+```
+
+Will appear under the fields:
+```
+message: hello
+foo: bar
 ```
 
 **Note:** The user must insert a valid JSON. Sending a dictionary or any key-value data structure that is not in a JSON format will cause the log to be sent as a string.

--- a/logzio-lambda-extensions-logs/utils/converter.go
+++ b/logzio-lambda-extensions-logs/utils/converter.go
@@ -63,7 +63,15 @@ func ConvertLambdaLogToLogzioLog(lambdaLog map[string]interface{}) map[string]in
 				logzioLog[FldLogzioMsg] = lambdaLog[FldLambdaRecord]
 			} else {
 				logger.Debugf("detected JSON: %s", lambdaLog[FldLambdaRecord])
-				logzioLog[FldLogzioMsgNested] = nested
+				if GetFlattenNestedMessage() {
+					if len(nested) > 0 {			
+						for key, val := range nested {
+							logzioLog[key] = val
+						}
+					}
+				} else {
+					logzioLog[FldLogzioMsgNested] = nested
+				}
 			}
 		}
 	default:

--- a/logzio-lambda-extensions-logs/utils/converter_test.go
+++ b/logzio-lambda-extensions-logs/utils/converter_test.go
@@ -51,7 +51,7 @@ func TestConverterSimpleJsonLogAndFlattenNestedMessage(t *testing.T) {
 	assert.Equal(t, lambdaLog[utils.FldLambdaTime], logzioLog[utils.FldLogzioTimestamp])
 	assert.Equal(t, lambdaLog[utils.FldLambdaType], logzioLog[utils.FldLogzioLambdaType])
 	assert.Equal(t, "hello", logzioLog["message"])
-	assert.Equal(t, "some", logzioLog["metadata"].(map[string]interface{})["object"])
+	assert.Equal(t, "object", logzioLog["some"].(map[string]interface{})["metadata"])
 }
 
 func TestConverterGrokFormattedLog(t *testing.T) {

--- a/logzio-lambda-extensions-logs/utils/converter_test.go
+++ b/logzio-lambda-extensions-logs/utils/converter_test.go
@@ -37,6 +37,23 @@ func TestConverterSimpleJsonLog(t *testing.T) {
 	assert.Equal(t, "bar", logzioLog[utils.FldLogzioMsgNested].(map[string]interface{})["foo"])
 }
 
+func TestConverterSimpleJsonLogAndFlattenNestedMessage(t *testing.T) {
+	os.Setenv("FLATTEN_NESTED_MESSAGE", "true")
+	lambdaLog := map[string]interface{}{
+		utils.FldLambdaTime:   "2021-11-11T08:28:16.870Z",
+		utils.FldLambdaType:   "function",
+		utils.FldLambdaRecord: "{\"message\": \"hello\", \"some\": {\"metadata\": \"object\"}}\n",
+	}
+
+	logzioLog := utils.ConvertLambdaLogToLogzioLog(lambdaLog)
+	assert.NotNil(t, logzioLog)
+	assert.NotZero(t, len(logzioLog))
+	assert.Equal(t, lambdaLog[utils.FldLambdaTime], logzioLog[utils.FldLogzioTimestamp])
+	assert.Equal(t, lambdaLog[utils.FldLambdaType], logzioLog[utils.FldLogzioLambdaType])
+	assert.Equal(t, "hello", logzioLog["message"])
+	assert.Equal(t, "some", logzioLog["metadata"].(map[string]interface{})["object"])
+}
+
 func TestConverterGrokFormattedLog(t *testing.T) {
 	os.Setenv("GROK_PATTERNS", "{\"app_name\":\"cool app\",\"my_message\":\".*\"}")
 	os.Setenv("LOGS_FORMAT", "%{app_name:my_app} : %{my_message:my_message}")

--- a/logzio-lambda-extensions-logs/utils/getters.go
+++ b/logzio-lambda-extensions-logs/utils/getters.go
@@ -115,5 +115,5 @@ func GetCustomFields() map[string]string {
 }
 
 func GetFlattenNestedMessage() bool {
-	return strings.EqualFold("true", os.Getenv(FLATTEN_NESTED_MESSAGE))
+	return strings.EqualFold("true", os.Getenv(envFlattenNestedMessage))
 }

--- a/logzio-lambda-extensions-logs/utils/getters.go
+++ b/logzio-lambda-extensions-logs/utils/getters.go
@@ -18,6 +18,7 @@ const (
 	envGrokPatterns            = "GROK_PATTERNS"
 	envLogsFormat              = "LOGS_FORMAT"
 	envCustomFields            = "CUSTOM_FIELDS"
+	envFlattenNestedMessage    = "FLATTEN_NESTED_MESSAGE"
 	envAwsLambdaFunctionName   = "AWS_LAMBDA_FUNCTION_NAME" // Reserved AWS env var
 	envAwsRegion               = "AWS_REGION"               //Reserved AWS env var
 	LogLevelDebug              = "debug"
@@ -111,4 +112,8 @@ func GetCustomFields() map[string]string {
 
 	logger.Debugf("detected %d custom fields", len(customFields))
 	return customFields
+}
+
+func GetFlattenNestedMessage() bool {
+	return strings.EqualFold("true", os.Getenv(FLATTEN_NESTED_MESSAGE))
 }


### PR DESCRIPTION
Added an `FLATTEN_NESTED_MESSAGE` environment variable, allowing log fields to be set as fields at the **root** of the object sent to logz.io, instead of under a `message_nested` field.  

It is useful in cases where the passed object is in fact meant to be that of a message plus metadata fields.  

For example, the following log:
```
{ "message": "hello", "foo": "bar" }
```
Will appear under the fields:
```
message: hello
foo: bar
```