### PR TITLE
Bugfix/arm auto release 0.3.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Build AMD ZIP File
         id: build-amd-zip
         working-directory: ./logzio-lambda-extensions-logs
-        run: ./build-zip.sh
+        run: |
+          chmod +x ./build-zip.sh
+          ./build-zip.sh
       - name: Publish AMD64 Layer Version
         if: (steps.setup-aws.outcome == 'success' && steps.build-amd-zip.outcome == 'success')
         id: publish-amd64
@@ -58,7 +60,9 @@ jobs:
       - name: Build ARM ZIP File
         id: build-arm-zip
         working-directory: ./logzio-lambda-extensions-logs
-        run: chmod +x ./build-arm-zip.sh
+        run: |
+          chmod +x ./build-arm-zip.sh
+          ./build-arm-zip.sh
       - name: Publish ARM64 Layer Version
         id: publish-arm64
         if: (steps.setup-aws.outcome == 'success' && steps.build-arm-zip.outcome == 'success')

--- a/logzio-lambda-extensions-logs/README.md
+++ b/logzio-lambda-extensions-logs/README.md
@@ -282,6 +282,8 @@ foo: bar
 **NOTE:** If your AWS region is not in the list, please reach out to Logz.io's support or open an issue in this repo.
 
 ### Changelog:
+- **0.3.5**:
+  - Fix ARM layer release
 - **0.3.4**:
   - Fix missing Lambda layer policy in release.
 - **0.3.3**:


### PR DESCRIPTION
I suspect that the current arm workflow does not create a new `exetention.zip` and it is using the `zip` archive created by the AMD workflow, so customers might get the wrong extension for their lambda arch. This pr fixes this issue.